### PR TITLE
chore(renovate): automerge minor/patch, group github-actions, min release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,5 +10,22 @@
   ],
   "reviewers": [
     "brpaz"
+  ],
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "matchManagers": [
+        "github-actions"
+      ],
+      "groupName": "github-actions"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Set `minimumReleaseAge` to 3 days (wait before proposing/merging a release, cheap insurance against bad patches)
- Automerge minor/patch updates if not already covered (packages at 1.0+; 0.x excluded)
- Group `github-actions` updates into a single PR if not already covered

Applied identically across all repos with a Renovate config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)